### PR TITLE
Misc fixes

### DIFF
--- a/dut-mode.el
+++ b/dut-mode.el
@@ -1,7 +1,5 @@
 ;;; dut-mode.el --- Major mode for the Dut programming language
 
-;;; Commentary:
-
 ;; Copyright 2017 The dut-mode Authors.  All rights reserved.
 ;; Use of this source code is governed by a MIT
 ;; license that can be found in the LICENSE file.
@@ -10,23 +8,20 @@
 ;; Version: 1.0
 ;; Keywords: languages gut
 ;; URL: https://github.com/dut-lang/dut-mode
+;; Package-Requires: ((emacs "24"))
 ;;
 ;; This file is not part of GNU Emacs.
 
+;;; Commentary:
+
+;; dut-mode is a major mode for editing code written in Dut
+;; Language.  It is a fork of the original squirrel-mode that provides
+;; compatibility with Emacs 24.3 and following versions.
+
 ;;; Code:
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.dut\\'" . dut-mode))
-
-(defvar dut-mode-hook nil)
-
-(defvar dut-mode-map
-  (let ((dut-mode-map (make-sparse-keymap)))
-    (define-key dut-mode-map "{" 'dut-electric-brace)
-    (define-key dut-mode-map "}" 'dut-electric-brace)
-    (define-key dut-mode-map ":" 'dut-electric-colon)
-    (define-key dut-mode-map "\C-c\C-o" 'dut-insert-block)
-    dut-mode-map)
-  "Keymap for dut major mode")
 
 (defvar dut-indent-level 4
   "Number of columns for a unit of indentation in dut mode.")
@@ -45,8 +40,7 @@
     (modify-syntax-entry ?* ". 23" dut-mode-syntax-table)
     (modify-syntax-entry ?\n "> b" dut-mode-syntax-table)
     dut-mode-syntax-table)
-  "Syntax table for dut-mode")
-
+  "Syntax table for dut-mode.")
 
 
 (defun dut-electric-brace (arg)
@@ -83,56 +77,57 @@
     (save-excursion
       (beginning-of-line)
       (let ((state (syntax-ppss)) level (indent-old 0) indent-new prev-level)
-    (if (nth 8 state)
-        () ;; Inside string or comment: do nothing
-      (setq prev-level (dut-continuation-indent-level))
-      (if prev-level
-          (indent-line-to (+ prev-level dut-indent-level)) ;; continuation line
-        (setq level (nth 0 state)) ;; get nest level
-        (if (looking-at "\\s-*\\(}\\|\\]\\|)\\)")
-        (setq level (1- level))
-          (if (looking-at "\\s-*\\(case\\|default\\)")
-          (setq level (1- level))))
-        (indent-line-to (* dut-indent-level (max 0 level))))
-      (setq pos1 (point)))))
+        (if (nth 8 state)
+            () ;; Inside string or comment: do nothing
+          (setq prev-level (dut-continuation-indent-level))
+          (if prev-level
+              (indent-line-to (+ prev-level dut-indent-level)) ;; continuation line
+            (setq level (nth 0 state)) ;; get nest level
+            (if (looking-at "\\s-*\\(}\\|\\]\\|)\\)")
+                (setq level (1- level))
+              (if (looking-at "\\s-*\\(case\\|default\\)")
+                  (setq level (1- level))))
+            (indent-line-to (* dut-indent-level (max 0 level))))
+          (setq pos1 (point)))))
     (if (> pos1 pos0)
-    (goto-char pos1))))
+        (goto-char pos1))))
 
 
 (defun dut-continuation-indent-level ()
   (save-excursion
     (while (forward-comment -1))
     (if (looking-back ")")
-    (condition-case nil
-        (progn
-          (goto-char (scan-sexps (point) -1))
-          (if (looking-at "(")
-          (progn
-            (while (forward-comment -1))
-            (if (looking-back "\\<\\(if\\|catch\\|while\\|for\\|foreach\\)")
-            (current-indentation)))))
-      (error nil))
+        (condition-case nil
+            (progn
+              (goto-char (scan-sexps (point) -1))
+              (if (looking-at "(")
+                  (progn
+                    (while (forward-comment -1))
+                    (if (looking-back "\\<\\(if\\|catch\\|while\\|for\\|foreach\\)")
+                        (current-indentation)))))
+          (error nil))
       (if (looking-back "\\<\\(else\\|try\\|in\\|instanceof\\|typeof\\)")
-      (current-indentation)
-    (if (looking-back "\\(\\+\\+\\|--\\)")
-        ()
-      (if (looking-back "[-+=~!/*%<>^|&?]")
-          (current-indentation)))))))
+          (current-indentation)
+        (if (looking-back "\\(\\+\\+\\|--\\)")
+            ()
+          (if (looking-back "[-+=~!/*%<>^|&?]")
+              (current-indentation)))))))
 
-(defun dut-mode ()
+;;;###autoload
+(define-derived-mode dut-mode prog-mode "dut"
   "Major mode for editing dut script"
-  (interactive)
-  (kill-all-local-variables)
-  (set-syntax-table dut-mode-syntax-table)
-  (use-local-map dut-mode-map)
   (set (make-local-variable 'font-lock-defaults) '(dut-font-lock-keywords))
   (set (make-local-variable 'indent-line-function) 'dut-indent-line)
   (set (make-local-variable 'comment-start) "// ")
   (set (make-local-variable 'comment-end) "")
-  (set (make-local-variable 'parse-sexp-ignore-comments) t)
+  (set (make-local-variable 'parse-sexp-ignore-comments) t))
 
-  (setq major-mode 'dut-mode)
-  (setq mode-name "dut")
-  (run-hooks 'dut-mode-hook))
+
+(define-key dut-mode-map "{" 'dut-electric-brace)
+(define-key dut-mode-map "}" 'dut-electric-brace)
+(define-key dut-mode-map ":" 'dut-electric-colon)
+(define-key dut-mode-map "\C-c\C-o" 'dut-insert-block)
+
 
 (provide 'dut-mode)
+;;; dut-mode.el ends here


### PR DESCRIPTION
- Fix package-specific formatting and indentation
- Use define-derived-mode to remove the need for boilerplate definitions
- Autoload file association and major mode

In connection with https://github.com/melpa/melpa/pull/4852